### PR TITLE
A barely-functional initial setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/bazel-*
+node_modules
+

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,4 @@
+package(default_visibility = ["//:__subpackages__"])
+
+filegroup(name = "node_modules", srcs = glob(["node_modules/**/*"]))
+# exports_files(["tsconfig.json"])

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,39 @@
+workspace(name = "protoc_ts_interface")
+
+http_archive(
+    name = "build_bazel_rules_nodejs",
+    url = "https://github.com/bazelbuild/rules_nodejs/archive/6b498e36095350bd88d2ea89e1a87ce791e51d82.zip",
+    strip_prefix = "rules_nodejs-6b498e36095350bd88d2ea89e1a87ce791e51d82",
+)
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+node_repositories(package_json = ["//:package.json"])
+
+http_archive(
+    name = "build_bazel_rules_typescript",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/0.6.0.zip",
+    strip_prefix = "rules_typescript-0.6.0",
+)
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_repositories")
+ts_repositories()
+
+# load("@build_bazel_rules_nodejs//:defs.bzl", "npm_install")
+# npm_install(
+#     name = "npm_install",
+#     package_json = "//:package.json",
+# )
+
+# Include @bazel/typescript in package.json#devDependencies
+# local_repository(
+#     name = "build_bazel_rules_typescript",
+#     path = "node_modules/@bazel/typescript",
+# )
+
+# load("@build_bazel_rules_typescript//:defs.bzl", "ts_repositories")
+
+# ts_repositories()
+
+http_archive(
+    name = "com_google_protobuf",
+    strip_prefix = "protobuf-3.5.0",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
+)

--- a/bin/BUILD
+++ b/bin/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//:__subpackages__"])
+
+filegroup(
+    name = "plugin_bin",
+    srcs = [
+        "protoc-gen-ts_interfaces",
+    ],
+)

--- a/bin/protoc-gen-ts_interfaces
+++ b/bin/protoc-gen-ts_interfaces
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("./protoc-gen-ts_interfaces.js")

--- a/bin/protoc-gen-ts_interfaces.js
+++ b/bin/protoc-gen-ts_interfaces.js
@@ -1,0 +1,1 @@
+../bazel-bin/src/protoc-gen-ts_interfaces.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "protoc-ts-interface",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@bazel/typescript": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@bazel/typescript/-/typescript-0.6.0.tgz",
+      "integrity": "sha512-QBRnMiHZywkeUjIVK9nACftdK8rUohLFjz27kdzQE+Zd13Gl5BMgoYA79khuz93AxJ/5SMltPLKXgMzlSoxYWA==",
+      "dev": true
+    },
+    "@types/google-protobuf": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.2.7.tgz",
+      "integrity": "sha512-Pb9wl5qDEwfnJeeu6Zpn5Y+waLrKETStqLZXHMGCTbkNuBBudPy4qOGN6veamyeoUBwTm2knOVeP/FlHHhhmzA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "8.0.57",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.57.tgz",
+      "integrity": "sha512-ZxrhcBxlZA7tn0HFf7ebUYfR9aHyBgjyavBLzyrYMYuAMbONBPY4S5O35562iV2FfwnZCjQky3gTDy1B3jSZ2Q==",
+      "dev": true
+    },
+    "google-protobuf": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.5.0.tgz",
+      "integrity": "sha1-uMxjx02DRXvYqakEUDyO+ya8ozk="
+    },
+    "typescript": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "protoc-ts-interface",
+  "version": "0.0.1",
+  "description": "protoc plugin that generates typescript interfaces from a protobuf schema",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sconover/protoc-ts-interface.git"
+  },
+  "author": "Steve Conover",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/sconover/protoc-ts-interface/issues"
+  },
+  "homepage": "https://github.com/sconover/protoc-ts-interface#readme",
+  "dependencies": {
+    "google-protobuf": "^3.2.7"
+  },
+  "devDependencies": {
+    "typescript": "^2.2.2",
+    "@bazel/typescript": "^0.6.0",
+    "@types/node": "^8.0.57",
+    "@types/google-protobuf": "^3.2.7"
+  }
+}

--- a/scenarios/01_basic_messages/BUILD
+++ b/scenarios/01_basic_messages/BUILD
@@ -1,0 +1,2 @@
+load("//util:protoc.bzl", "proto_to_ts_interfaces")
+proto_to_ts_interfaces(["plain_email.proto"])

--- a/scenarios/01_basic_messages/plain_email.proto
+++ b/scenarios/01_basic_messages/plain_email.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package plain_email;
+
+message Identity {
+  string name = 1;
+  string email = 2;
+}
+
+message PlainEmail {
+  Identity from = 1;
+  Identity to = 2;
+  string body_text = 3;
+}

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//:__subpackages__"])
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+ts_library(
+    name = "ts_lib",
+    srcs = [
+        "protoc-gen-ts_interfaces.ts",
+    ],
+    # tsconfig = "//:tsconfig.json",
+    # deps = ["//:node_modules"],
+    # module_name = "sm",
+)

--- a/src/protoc-gen-ts_interfaces.ts
+++ b/src/protoc-gen-ts_interfaces.ts
@@ -1,0 +1,35 @@
+import {CodeGeneratorRequest, CodeGeneratorResponse} from "google-protobuf/google/protobuf/compiler/plugin_pb";
+import {FileDescriptorProto} from "google-protobuf/google/protobuf/descriptor_pb";
+
+const stdin = process.stdin;
+stdin.on("readable", function () {
+  try {
+    let chunk
+
+    while ((chunk = stdin.read())) {
+        if (!(chunk instanceof Buffer)) throw new Error("Did not receive buffer")
+
+        const typedInputBuff = new Uint8Array(chunk.length)
+        typedInputBuff.set(chunk)
+
+        const codeGenRequest = CodeGeneratorRequest.deserializeBinary(typedInputBuff)
+    }
+  } catch (err) {
+    console.error("protoc-gen-ts_interfaces error: " + err.stack + "\n");
+    process.exit(1);
+  }
+});
+
+const outTsFile = new CodeGeneratorResponse.File()
+outTsFile.setName("generated.d.ts");
+outTsFile.setContent(
+`
+interface HelloInterface {
+  name: string;
+}
+`
+);
+const codeGenResponse = new CodeGeneratorResponse()
+codeGenResponse.addFile(outTsFile)
+
+process.stdout.write(new Buffer(codeGenResponse.serializeBinary()));

--- a/util/protoc.bzl
+++ b/util/protoc.bzl
@@ -1,0 +1,15 @@
+def proto_to_ts_interfaces(proto_files=[]):
+    native.genrule(
+        name="proto_to_ts_interfaces",
+        cmd="outdir=$$(dirname $@); $(location @com_google_protobuf//:protoc) --plugin=protoc-gen-ts_interfaces=$(location //bin:plugin_bin) -I . $(location %s) --ts_interfaces_out=$$outdir" % proto_files[0],
+        outs=["generated.d.ts"],
+        srcs=[
+            "//bin:plugin_bin",
+            "//src:ts_lib", # forces this module to rebuild on modification of inputs, which doesn't happen otherwise (weird)
+            proto_files[0],
+        ],
+        tools=[
+            "@com_google_protobuf//:protoc",
+            "//bin:plugin_bin",
+        ],
+    )


### PR DESCRIPTION
- compiles the plugin implementation (which is itself ts) to js
- bin script that executes aforementioned js
- bazel build rules to make all of the above happen
- results is a plugin that results in exit 0 but does not do anything
  of real use (just outputs a hardcoded ts interface)