### PR TITLE
Transform proto enums to ts const enums

### DIFF
--- a/scenarios/01_basic_messages/expected.d.ts
+++ b/scenarios/01_basic_messages/expected.d.ts
@@ -1,14 +1,27 @@
 declare namespace plain_email {
 
+  const enum AttachmentType {
+    NONE = 0,
+    PDF = 1,
+    ZIP = 2
+  }
+  
+  const enum EncryptionType {
+    NONE = 0,
+    ENCRYPTED = 1
+  }
+  
   interface Identity {
     name: string
     email: string
   }
   
   interface PlainEmail {
-    from: plain_email.Identity
-    to: plain_email.Identity
+    from: Identity
+    to: Identity
     body_text: string
+    attach_type: AttachmentType
+    encrypt_type: EncryptionType
   }
 
 }

--- a/scenarios/01_basic_messages/plain_email.proto
+++ b/scenarios/01_basic_messages/plain_email.proto
@@ -6,8 +6,22 @@ message Identity {
   string email = 2;
 }
 
+enum EncryptionType {
+  NONE = 0;
+  ENCRYPTED = 1;
+}
+
 message PlainEmail {
+
+  enum AttachmentType {
+    NONE = 0;
+    PDF = 1;
+    ZIP = 2;
+  }
+
   Identity from = 1;
   Identity to = 2;
   string body_text = 3;
+  AttachmentType attach_type = 4;
+  EncryptionType encrypt_type = 5;
 }


### PR DESCRIPTION
add in-message enum to scenario fixtures
failing enum test, WIP
enable enum type mapping, treat enum fields as we do message fields, for ts member codegen
assert that ts enum const gets created
don't unnecessarily qualify interfaces and enums defined within the same namespace
demonstrate enums that are sibling to messages