### PR TITLE
Support nesting of messages and enums (in messages)

### DIFF
--- a/scenarios/01_basic_messages/expected.d.ts
+++ b/scenarios/01_basic_messages/expected.d.ts
@@ -1,14 +1,26 @@
 declare namespace plain_email {
 
-  const enum AttachmentType {
-    NONE = 0,
-    PDF = 1,
-    ZIP = 2
-  }
-  
   const enum EncryptionType {
     NONE = 0,
     ENCRYPTED = 1
+  }
+  
+  module Identity {
+  
+    module SecretKey {
+    
+      const enum KeyType {
+        PGP = 0,
+        OTHER = 1
+      }
+    
+    }
+    
+    interface SecretKey {
+      key_type: plain_email.Identity.SecretKey.KeyType
+      key: string
+    }
+  
   }
   
   interface Identity {
@@ -16,12 +28,22 @@ declare namespace plain_email {
     email: string
   }
   
+  module PlainEmail {
+  
+    const enum AttachmentType {
+      NONE = 0,
+      PDF = 1,
+      ZIP = 2
+    }
+  
+  }
+  
   interface PlainEmail {
-    from: Identity
-    to: Identity
+    from: plain_email.Identity
+    to: plain_email.Identity
     body_text: string
-    attach_type: AttachmentType
-    encrypt_type: EncryptionType
+    attach_type: plain_email.PlainEmail.AttachmentType
+    encrypt_type: plain_email.EncryptionType
   }
 
 }

--- a/scenarios/01_basic_messages/plain_email.proto
+++ b/scenarios/01_basic_messages/plain_email.proto
@@ -4,6 +4,16 @@ package plain_email;
 message Identity {
   string name = 1;
   string email = 2;
+
+  message SecretKey {
+    enum KeyType {
+      PGP = 0;
+      OTHER = 1;
+    }
+
+    KeyType key_type = 1;
+    string key = 2;
+  }
 }
 
 enum EncryptionType {
@@ -25,3 +35,4 @@ message PlainEmail {
   AttachmentType attach_type = 4;
   EncryptionType encrypt_type = 5;
 }
+

--- a/scenarios/02_service/baker.proto
+++ b/scenarios/02_service/baker.proto
@@ -18,3 +18,4 @@ service BakerService {
   rpc PleaseBakeCake (PleaseBakeCakeRequest) returns (PleaseBakeCakeResponse) {
   }
 }  
+

--- a/scenarios/02_service/expected.d.ts
+++ b/scenarios/02_service/expected.d.ts
@@ -10,11 +10,11 @@ declare namespace baker {
   }
   
   interface PleaseBakeCakeResponse {
-    deliciousness: Deliciousness
+    deliciousness: baker.Deliciousness
   }
   
   interface BakerService {
-    pleaseBakeCake(request: PleaseBakeCakeRequest): Promise<PleaseBakeCakeResponse>
+    pleaseBakeCake(request: baker.PleaseBakeCakeRequest): Promise<baker.PleaseBakeCakeResponse>
   }
 
 }


### PR DESCRIPTION
- Make a ts module named the same name as the interface.
- Use fully qualified types for interface members

rip out all of the defensive code and manipulation of field namespaces
WIP - nested message via modules - scenario tests pass
test for nested messages