### PR TITLE
Ensure that the ts gen'd results in objects that are directly JSON.st…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /bazel-*
 node_modules
 .vscode
+*.iml
+.idea
+out/

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,6 @@
 - generate ts interfaces via protoc plugin
 - reuses parts of https://github.com/improbable-eng/ts-protoc-gen
+- JSON.stringify of the ts object results in json that is deserializable by other proto libraries
 
 dev setup:
 - install bazel
@@ -10,3 +11,9 @@ dev setup:
   - this includes usage of the plugin to gen d.ts's for the various scenarios in the scenarios directory
 - to run tests: bazel test //...
 - followed http://blog.npmjs.org/post/118810260230/building-a-simple-command-line-tool-with-npm to make the cli and publish the package to the npm repo
+
+TODO (known):
+  - maps, per https://developers.google.com/protocol-buffers/docs/proto3#json
+  - bytes / b64
+  - timestamp
+  - duration

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,9 @@
 workspace(name = "protoc_ts_interfaces")
 
+maven_jar(name="com_google_code_gson_gson",                      artifact="com.google.code.gson:gson:2.8.2")
+maven_jar(name="com_google_google_guava",                        artifact="com.google.guava:guava:19.0")
+maven_jar(name="com_google_protobuf_java_util",                  artifact="com.google.protobuf:protobuf-java-util:3.5.0")
+
 http_archive(
     name = "build_bazel_rules_nodejs",
     url = "https://github.com/bazelbuild/rules_nodejs/archive/6b498e36095350bd88d2ea89e1a87ce791e51d82.zip",
@@ -16,24 +20,31 @@ http_archive(
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_repositories")
 ts_repositories()
 
-# load("@build_bazel_rules_nodejs//:defs.bzl", "npm_install")
-# npm_install(
-#     name = "npm_install",
-#     package_json = "//:package.json",
-# )
-
-# Include @bazel/typescript in package.json#devDependencies
-# local_repository(
-#     name = "build_bazel_rules_typescript",
-#     path = "node_modules/@bazel/typescript",
-# )
-
-# load("@build_bazel_rules_typescript//:defs.bzl", "ts_repositories")
-
-# ts_repositories()
-
 http_archive(
     name = "com_google_protobuf",
     strip_prefix = "protobuf-3.5.0",
     urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
 )
+
+http_archive(
+    name = "com_google_protobuf_java",
+    strip_prefix = "protobuf-3.5.0",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.0.tar.gz"],
+)
+
+rules_intellij_generate_sha = "c0dcaa85aeb0e266fb531e84018efdf173d4be17"
+http_archive(
+    name = "rules_intellij_generate",
+    url = "https://github.com/sconover/rules_intellij_generate/archive/%s.tar.gz" % rules_intellij_generate_sha,
+    strip_prefix = "rules_intellij_generate-%s/rules" % rules_intellij_generate_sha,
+)
+load("@rules_intellij_generate//:def.bzl", "repositories_for_intellij_generate")
+repositories_for_intellij_generate()
+
+http_archive(
+    name = "rules_junit5",
+    url = "https://github.com/sconover/rules_intellij_generate/archive/%s.tar.gz" % rules_intellij_generate_sha,
+    strip_prefix = "rules_intellij_generate-%s/rules_junit5" % rules_intellij_generate_sha,
+)
+load("@rules_junit5//:def.bzl", "junit5_repositories")
+junit5_repositories()

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,12 @@
       "integrity": "sha512-ZxrhcBxlZA7tn0HFf7ebUYfR9aHyBgjyavBLzyrYMYuAMbONBPY4S5O35562iV2FfwnZCjQky3gTDy1B3jSZ2Q==",
       "dev": true
     },
+    "@types/text-encoding": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/text-encoding/-/text-encoding-0.0.32.tgz",
+      "integrity": "sha512-kQ79aFmYcD/DR3QKo6wXyvNrKi7PunY0KYTBUhHjHl0SXwWuLRl9Leh73YtnsSJMBi9qSiK+fxWhdJNQPbhc9A==",
+      "dev": true
+    },
     "@types/typescript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/typescript/-/typescript-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protoc-ts-interfaces",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "[WIP/alpha] protoc plugin that generates typescript interfaces from a protobuf schema",
   "main": "index.js",
   "bin": {

--- a/scenarios/01_basic_messages/expected.d.ts
+++ b/scenarios/01_basic_messages/expected.d.ts
@@ -1,8 +1,8 @@
 export namespace plain_email {
 
   const enum EncryptionType {
-    NONE = 0,
-    ENCRYPTED = 1
+    NONE = "NONE",
+    ENCRYPTED = "ENCRYPTED"
   }
   
   module Identity {
@@ -10,15 +10,15 @@ export namespace plain_email {
     module SecretKey {
     
       const enum KeyType {
-        PGP = 0,
-        OTHER = 1
+        PGP = "PGP",
+        OTHER = "OTHER"
       }
     
     }
     
     interface SecretKey {
-      key_type: plain_email.Identity.SecretKey.KeyType
-      key: string
+      keyType: plain_email.Identity.SecretKey.KeyType
+      key: string[]
     }
   
   }
@@ -31,25 +31,25 @@ export namespace plain_email {
   module PlainEmail {
   
     const enum AttachmentType {
-      NONE = 0,
-      PDF = 1,
-      ZIP = 2
+      NONE = "NONE",
+      PDF = "PDF",
+      ZIP = "ZIP"
     }
   
   }
   
   interface PlainEmail {
     from: plain_email.Identity
-    to: plain_email.Identity
-    body_text: string
-    attach_type: plain_email.PlainEmail.AttachmentType
-    encrypt_type: plain_email.EncryptionType
+    to: plain_email.Identity[]
+    bodyText: string
+    attachType: plain_email.PlainEmail.AttachmentType
+    encryptType: plain_email.EncryptionType
   }
   
   interface PlainEmail2 {
     from2: plain_email.Identity
     to2: plain_email.Identity
-    body_text2: string
+    bodyText2: string
   }
 
 }
@@ -61,8 +61,8 @@ export namespace some {
     namespace html_email {
     
       interface HtmlEmail {
-        plain_email: plain_email.PlainEmail
-        body_html: string
+        plainEmail: plain_email.PlainEmail
+        bodyHtml: string
       }
     
     }

--- a/scenarios/01_basic_messages/plain_email.proto
+++ b/scenarios/01_basic_messages/plain_email.proto
@@ -12,7 +12,7 @@ message Identity {
     }
 
     KeyType key_type = 1;
-    string key = 2;
+    repeated string key = 2;
   }
 }
 
@@ -30,7 +30,7 @@ message PlainEmail {
   }
 
   Identity from = 1;
-  Identity to = 2;
+  repeated Identity to = 2;
   string body_text = 3;
   AttachmentType attach_type = 4;
   EncryptionType encrypt_type = 5;

--- a/scenarios/02_service/expected.d.ts
+++ b/scenarios/02_service/expected.d.ts
@@ -1,8 +1,8 @@
 export namespace baker {
 
   const enum Deliciousness {
-    ITS_OK = 0,
-    QUITE_DELICIOUS_SIR = 1
+    ITS_OK = "ITS_OK",
+    QUITE_DELICIOUS_SIR = "QUITE_DELICIOUS_SIR"
   }
   
   interface PleaseBakeCakeRequest {

--- a/scenarios/03_compare_to_java_json/BUILD
+++ b/scenarios/03_compare_to_java_json/BUILD
@@ -1,0 +1,64 @@
+load("//util:protoc.bzl", "proto_to_ts_interfaces")
+load("@rules_intellij_generate//:def.bzl", "intellij_source_java_library")
+
+proto_to_ts_interfaces(["various.proto"])
+exports_files(["expected.d.ts", "various.proto"])
+
+proto_library(
+    name = "03_compare_to_java_json_proto",
+    srcs = ["various.proto"],
+)
+
+java_proto_library(
+    name = "java_proto",
+    deps = [":03_compare_to_java_json_proto"],
+)
+
+intellij_source_java_library(
+    name="lib",
+    source_folder_to_wildcard_map={"javasrc":"**/*.java"},
+    deps=[
+        ":java_proto",
+        
+        "@com_google_code_gson_gson//jar",
+        "@com_google_google_guava//jar",
+        "@com_google_protobuf_java//:protobuf_java",
+        "@com_google_protobuf_java_util//jar",
+    ]
+)
+
+java_binary(
+    name="gen_json_from_java",
+    deps=[
+        ":java_proto",
+        ":lib",
+
+        "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf_java_util//jar",
+    ],
+    srcs=glob(["javasrc/**/*.java"]),
+    main_class="protoctsinterfaces.PrintProtoJson",
+    args=[
+        "bar.json"
+    ]
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_iml")
+intellij_iml(
+    name = "iml",
+    java_source=":lib",
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_modules_xml")
+intellij_modules_xml(
+    name = "modules_xml",
+    deps = [
+      ":iml",
+    ]
+)
+
+load("@rules_intellij_generate//:def.bzl", "intellij_project")
+intellij_project(
+  name="idea_project",
+  intellij_modules_xml=":modules_xml",
+)

--- a/scenarios/03_compare_to_java_json/expected.d.ts
+++ b/scenarios/03_compare_to_java_json/expected.d.ts
@@ -1,0 +1,30 @@
+export namespace various {
+
+  const enum ExampleEnum {
+    FIRST_OPTION = "FIRST_OPTION",
+    SECOND_OPTION = "SECOND_OPTION"
+  }
+  
+  interface Primitives {
+    exampleString: string
+    exampleInt: number
+    exampleLong: number
+    exampleFloat: number
+    exampleDouble: number
+    exampleBool: boolean
+    exampleBytes: Uint8Array | string
+  }
+  
+  interface Container {
+    name: string
+    onePrimitive: various.Primitives
+    oneEnumValue: various.ExampleEnum
+  }
+  
+  interface Repetition {
+    names: string[]
+    manyEnumValues: various.ExampleEnum[]
+    manyContainers: various.Container[]
+  }
+
+}

--- a/scenarios/03_compare_to_java_json/expected.json
+++ b/scenarios/03_compare_to_java_json/expected.json
@@ -1,0 +1,28 @@
+{
+  "manyContainers": [
+    {
+      "name": "this is the container name",
+      "onePrimitive": {
+        "exampleString": "this is an example string value",
+        "exampleInt": 77,
+        "exampleLong": 78,
+        "exampleFloat": 77.78,
+        "exampleDouble": 78.78,
+        "exampleBool": true
+      },
+      "oneEnumValue": "SECOND_OPTION"
+    },
+    {
+      "name": "this is the second container"
+    }
+  ],
+  "manyEnumValues": [
+    "SECOND_OPTION",
+    "SECOND_OPTION",
+    "FIRST_OPTION"
+  ],
+  "names": [
+    "name one",
+    "name two"
+  ]
+}

--- a/scenarios/03_compare_to_java_json/javasrc/protoctsinterfaces/PrintProtoJson.java
+++ b/scenarios/03_compare_to_java_json/javasrc/protoctsinterfaces/PrintProtoJson.java
@@ -1,0 +1,40 @@
+package protoctsinterfaces;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import various.Various;
+
+class PrintProtoJson {
+  public static void main(String[] args) {
+    Various.Repetition message = Various.Repetition.newBuilder()
+      .addManyContainers(
+        Various.Container.newBuilder()
+          .setName("this is the container name")
+          .setOnePrimitive(
+            Various.Primitives.newBuilder()
+              .setExampleString("this is an example string value")
+              .setExampleInt(77)
+              .setExampleLong(78)
+              .setExampleFloat(77.78f)
+              .setExampleDouble(78.78)
+              .setExampleBool(true)
+              .setExampleBytes(ByteString.copyFrom("abc".getBytes())))
+          .setOneEnumValue(Various.ExampleEnum.SECOND_OPTION))
+      .addManyContainers(
+        Various.Container.newBuilder()
+          .setName("this is the second container"))
+      .addManyEnumValues(Various.ExampleEnum.SECOND_OPTION)
+      .addManyEnumValues(Various.ExampleEnum.SECOND_OPTION)
+      .addManyEnumValues(Various.ExampleEnum.FIRST_OPTION)
+      .addNames("name one")
+      .addNames("name two")
+      .build();
+
+    try {
+      System.out.println(JsonFormat.printer().print(message));
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/scenarios/03_compare_to_java_json/various.proto
+++ b/scenarios/03_compare_to_java_json/various.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package various;
+
+// see proto3 json rules here: https://developers.google.com/protocol-buffers/docs/proto3#json
+
+message Primitives {
+  string example_string = 1;
+  int32 example_int = 2;
+  int64 example_long = 3;
+  float example_float = 4;
+  double example_double = 5;
+  bool example_bool = 6;
+  bytes example_bytes = 7;
+}
+
+enum ExampleEnum {
+  FIRST_OPTION = 0;
+  SECOND_OPTION = 1;
+}
+
+message Container {
+  string name = 1;
+  Primitives one_primitive = 2;
+  ExampleEnum one_enum_value = 3;
+}
+
+message Repetition {
+  repeated string names = 1;
+  repeated ExampleEnum many_enum_values = 2;
+  repeated Container many_containers = 3;
+}

--- a/test/BUILD
+++ b/test/BUILD
@@ -11,4 +11,5 @@ ts_test(test_file = "scenario_test.ts",
         "//scenarios/01_basic_messages:plain_email_bonus.proto",
         "//scenarios/02_service:expected.d.ts",
         "//scenarios/02_service:baker.proto",
+        "//scenarios/03_compare_to_java_json:various.proto",
     ])

--- a/test/scenario_test.ts
+++ b/test/scenario_test.ts
@@ -5,6 +5,8 @@ const assert: any = require("assert")
 var fs = require('fs')
 var path = require('path')
 
+import { various } from "../bazel-genfiles/scenarios/03_compare_to_java_json/proto.generated"
+
 suite("scenario", () => {
   test("01_basic_messages", () => {
     const expectedContent = fs.readFileSync(path.join(__dirname, "../scenarios/01_basic_messages/expected.d.ts")).toString()
@@ -17,4 +19,43 @@ suite("scenario", () => {
     const actualContent = fs.readFileSync(path.join(__dirname, "../bazel-genfiles/scenarios/02_service/proto.generated.d.ts")).toString()
     assert.equal(expectedContent, actualContent)
   })
+
+  test("03_compare_to_java_json", () => {
+    const expectedContent = fs.readFileSync(path.join(__dirname, "../scenarios/03_compare_to_java_json/expected.d.ts")).toString()
+    const actualContent = fs.readFileSync(path.join(__dirname, "../bazel-genfiles/scenarios/03_compare_to_java_json/proto.generated.d.ts")).toString()
+    assert.equal(expectedContent, actualContent)
+  })
+
+  test("json comparison: 03_compare_to_java_json", () => {
+    const tsPrimitiveObj:various.Primitives = (<various.Primitives>new Object())
+    tsPrimitiveObj.exampleString = "this is an example string value"
+    tsPrimitiveObj.exampleInt = 77
+    tsPrimitiveObj.exampleLong = 78
+    tsPrimitiveObj.exampleFloat = 77.78
+    tsPrimitiveObj.exampleDouble = 78.78
+    tsPrimitiveObj.exampleBool = true
+
+    const tsContainerObj:various.Container = (<various.Container>new Object())
+    tsContainerObj.name = "this is the container name"
+    tsContainerObj.onePrimitive = tsPrimitiveObj
+    tsContainerObj.oneEnumValue = various.ExampleEnum.SECOND_OPTION
+
+    const tsRepetitionObj:various.Repetition = (<various.Repetition>new Object())
+    tsRepetitionObj.manyContainers = [
+      tsContainerObj,
+      (<various.Container>{name: "this is the second container"})
+    ]
+    tsRepetitionObj.manyEnumValues = [
+      various.ExampleEnum.SECOND_OPTION, 
+      various.ExampleEnum.SECOND_OPTION, 
+      various.ExampleEnum.FIRST_OPTION
+    ]
+    tsRepetitionObj.names = ["name one", "name two"]
+    // tsObj.exampleBytes = new TextEncoder("utf-8").encode("abc");
+
+    var tsJsonStringifiedPretty = JSON.stringify(tsRepetitionObj, null, 2);
+    const expectedJson = fs.readFileSync(path.join(__dirname, "../scenarios/03_compare_to_java_json/expected.json")).toString()
+    assert.equal(expectedJson, tsJsonStringifiedPretty)
+  })
 })
+

--- a/test/transform_test.ts
+++ b/test/transform_test.ts
@@ -290,16 +290,16 @@ suite("transform", () => {
             .addMessageType(
               new MessageTypeProtoBuilder()
                 .setName("FortuneCookie")
-                .addPrimitiveField("fortune_content", FieldDescriptorProto.Type.TYPE_STRING)
-                .addPrimitiveField("fortune_number", FieldDescriptorProto.Type.TYPE_INT32)
+                .addPrimitiveField("fortuneContent", FieldDescriptorProto.Type.TYPE_STRING)
+                .addPrimitiveField("fortuneNumber", FieldDescriptorProto.Type.TYPE_INT32)
                 .build())
           .build())
         .build())
 
     assert.deepEqual(
       ["FortuneCookie", [
-        ["fortune_content", "StringKeyword"], 
-        ["fortune_number", "NumberKeyword"]]], 
+        ["fortuneContent", "StringKeyword"], 
+        ["fortuneNumber", "NumberKeyword"]]], 
       extractInterfaceInfo(childNode(codeGenResponse, 0)))
   })
 
@@ -307,8 +307,8 @@ suite("transform", () => {
     const fortuneCookieMessageType = 
       new MessageTypeProtoBuilder()
         .setName("FortuneCookie")
-        .addPrimitiveField("fortune_content", FieldDescriptorProto.Type.TYPE_STRING)
-        .addPrimitiveField("fortune_number", FieldDescriptorProto.Type.TYPE_INT32)
+        .addPrimitiveField("fortuneContent", FieldDescriptorProto.Type.TYPE_STRING)
+        .addPrimitiveField("fortuneNumber", FieldDescriptorProto.Type.TYPE_INT32)
         .build()
     const codeGenResponse = transform(
       new CodeGeneratorRequestBuilder()
@@ -326,13 +326,13 @@ suite("transform", () => {
 
     assert.deepEqual(
       ["FortuneCookie", [
-        ["fortune_content", "StringKeyword"], 
-        ["fortune_number", "NumberKeyword"]]], 
+        ["fortuneContent", "StringKeyword"], 
+        ["fortuneNumber", "NumberKeyword"]]], 
       extractInterfaceInfo(childNode(codeGenResponse, 0)))
 
     assert.deepEqual(
       ["FinalBill", [
-        ["amount_cents", "NumberKeyword"], 
+        ["amountCents", "NumberKeyword"], 
         ["cookie", "FortuneCookie"]]], 
       extractInterfaceInfo(childNode(codeGenResponse, 1)))
   })
@@ -341,8 +341,8 @@ suite("transform", () => {
     const fortuneCookieMessageType =
       new MessageTypeProtoBuilder()
         .setName("FortuneCookie")
-        .addPrimitiveField("fortune_content", FieldDescriptorProto.Type.TYPE_STRING)
-        .addPrimitiveField("fortune_number", FieldDescriptorProto.Type.TYPE_INT32)
+        .addPrimitiveField("fortuneContent", FieldDescriptorProto.Type.TYPE_STRING)
+        .addPrimitiveField("fortuneNumber", FieldDescriptorProto.Type.TYPE_INT32)
         .build()
     const codeGenResponse = transform(
       new CodeGeneratorRequestBuilder()
@@ -353,7 +353,7 @@ suite("transform", () => {
             .addMessageType(
               new MessageTypeProtoBuilder()
                 .setName("FinalBill")
-                .addPrimitiveField("amount_cents", FieldDescriptorProto.Type.TYPE_INT32)
+                .addPrimitiveField("amountCents", FieldDescriptorProto.Type.TYPE_INT32)
                 .addMessageField("cookie", fortuneCookieMessageType, "single_level_package")
                 .build())
           .build())
@@ -367,13 +367,13 @@ suite("transform", () => {
 
     assert.deepEqual(
       ["FortuneCookie", [
-        ["fortune_content", "StringKeyword"],
-        ["fortune_number", "NumberKeyword"]]],
+        ["fortuneContent", "StringKeyword"],
+        ["fortuneNumber", "NumberKeyword"]]],
       extractInterfaceInfo(interfaceNodes[0]))
 
     assert.deepEqual(
       ["FinalBill", [
-        ["amount_cents", "NumberKeyword"],
+        ["amountCents", "NumberKeyword"],
         ["cookie", "FortuneCookie"]]],
       extractInterfaceInfo(interfaceNodes[1]))
   })
@@ -410,21 +410,21 @@ suite("transform", () => {
 
     assert.deepEqual(
       ["Smorgasbord", [
-        ["originally_double", "NumberKeyword"], 
-        ["originally_float", "NumberKeyword"], 
-        ["originally_int64", "NumberKeyword"], 
-        ["originally_uint64", "NumberKeyword"], 
-        ["originally_int32", "NumberKeyword"], 
-        ["originally_fixed64", "NumberKeyword"], 
-        ["originally_fixed32", "NumberKeyword"], 
-        ["originally_bool", "BooleanKeyword"], 
-        ["originally_string", "StringKeyword"], 
-        ["originally_bytes", "UnionType"], 
-        ["originally_uint32", "NumberKeyword"], 
-        ["originally_sfixed32", "NumberKeyword"], 
-        ["originally_sfixed64", "NumberKeyword"], 
-        ["originally_sint32", "NumberKeyword"], 
-        ["originally_sint64", "NumberKeyword"]]], 
+        ["originallyDouble", "NumberKeyword"], 
+        ["originallyFloat", "NumberKeyword"], 
+        ["originallyInt64", "NumberKeyword"], 
+        ["originallyUint64", "NumberKeyword"], 
+        ["originallyInt32", "NumberKeyword"], 
+        ["originallyFixed64", "NumberKeyword"], 
+        ["originallyFixed32", "NumberKeyword"], 
+        ["originallyBool", "BooleanKeyword"], 
+        ["originallyString", "StringKeyword"], 
+        ["originallyBytes", "UnionType"], 
+        ["originallyUint32", "NumberKeyword"], 
+        ["originallySfixed32", "NumberKeyword"], 
+        ["originallySfixed64", "NumberKeyword"], 
+        ["originallySint32", "NumberKeyword"], 
+        ["originallySint64", "NumberKeyword"]]], 
       extractInterfaceInfo(childNode(codeGenResponse, 0)))
   })
 
@@ -444,7 +444,7 @@ suite("transform", () => {
               new MessageTypeProtoBuilder()
                 .setName("FortuneCookie")
                 .addEnumType(protoFortuneKindEnum)
-                .addPrimitiveField("fortune_content", FieldDescriptorProto.Type.TYPE_STRING)
+                .addPrimitiveField("fortuneContent", FieldDescriptorProto.Type.TYPE_STRING)
                 .addEnumField("fortune_kind", protoFortuneKindEnum)
                 .build())
           .build())
@@ -460,8 +460,8 @@ suite("transform", () => {
 
     assert.deepEqual(
       ["FortuneCookie", [
-        ["fortune_content", "StringKeyword"], 
-        ["fortune_kind", "FortuneKind"]]], 
+        ["fortuneContent", "StringKeyword"], 
+        ["fortuneKind", "FortuneKind"]]], 
       extractInterfaceInfo(childNode(codeGenResponse, 1)))
   })
 
@@ -473,7 +473,7 @@ suite("transform", () => {
 
     const responseType: DescriptorProto = new MessageTypeProtoBuilder()
       .setName("GetRandomFortuneResponse")
-      .addPrimitiveField("fortune_content", FieldDescriptorProto.Type.TYPE_STRING)
+      .addPrimitiveField("fortuneContent", FieldDescriptorProto.Type.TYPE_STRING)
       .build();
 
     const codeGenResponse = transform(
@@ -496,7 +496,7 @@ suite("transform", () => {
 
     assert.deepEqual(
       ["GetRandomFortuneResponse", [
-        ["fortune_content", "StringKeyword"]]], 
+        ["fortuneContent", "StringKeyword"]]], 
       extractInterfaceInfo(childNode(codeGenResponse, 1)))
 
     assert.deepEqual(


### PR DESCRIPTION
…ringify-able, and that that json can be parsed by the java proto library

Also introduce repeated fields

basic ts scenario test
failing scenario test that compares json
camelize ts interfaces members, to match proto json standards
more primitive types
container proto
change enums to have values the same as their names, per the spec
convert existing tests to reflect new standards
core support for repeated fields, represented as arrays
prove repetition json is the same as emitted from the java proto lib
README notes